### PR TITLE
feat: Embed Google Map in Venue Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,11 +141,7 @@
             <h2 class="text-5xl text-center text-gold font-bold mb-12 gold-text">The Venue</h2>
             <div class="container mx-auto px-4">
                 <p class="text-xl mb-8">All ceremonies will be held at the majestic Jaypee Palace Hotel & Convention Centre, Agra.</p>
-                <a href="https://www.google.com/maps/place/Jaypee+Palace+Hotel+%26+Convention+Centre/@27.174154,78.058912,15z/data=!4m2!3m1!1s0x0:0xad7208836511e61b?sa=X&ved=2ahUKEwjY5q-w4b_8AhXfR2wGHc0QBw4Q_BIwHnoECBQQAg" target="_blank" rel="noopener noreferrer" class="venue-icon-link inline-block bg-gold text-maroon p-4 rounded-full hover:bg-opacity-80 transition-all">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12" viewBox="0 0 20 20" fill="currentColor">
-                        <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd" />
-                    </svg>
-                </a>
+                <iframe src="https://maps.google.com/maps?q=Jaypee%20Palace%20Hotel%20&%20Convention%20Centre,%20Agra&t=&z=13&ie=UTF8&iwloc=&output=embed" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" class="embedded-map"></iframe>
             </div>
         </section>
 

--- a/style.css
+++ b/style.css
@@ -206,3 +206,9 @@ body {
             from { transform: rotate(0deg); }
             to { transform: rotate(-360deg); }
         }
+
+        .embedded-map {
+            border: 4px solid #FFD700;
+            border-radius: 15px;
+            box-shadow: 0 10px 20px rgba(0,0,0,0.3);
+        }


### PR DESCRIPTION
Replaced the external Google Maps link with an embedded iframe to display the venue map directly on the page.

Added custom styling to the embedded map to ensure it is visually consistent with the website's design, including a gold border, rounded corners, and a box shadow.